### PR TITLE
Remove fixed version to avoid crash at runtime

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -8,9 +8,10 @@ repositories {
     }
 }
 
-ext {
-    cdvCompileSdkVersion = 26
-    cdvBuildToolsVersion = "26.0.0"
+def DEFAULT_MIN_SDK_VERSION = 21
+def minSdk = Math.max(DEFAULT_MIN_SDK_VERSION, cdvHelpers.getConfigPreference('android-minSdkVersion', 0) as Integer);
+if (cdvMinSdkVersion == null || Integer.parseInt('' + cdvMinSdkVersion) < minSdk ) {
+    ext.cdvMinSdkVersion = minSdk;
 }
 
 dependencies {

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -15,5 +15,5 @@ ext {
 
 dependencies {
     compile 'org.kisio.sdk:navitia-sdk-ux:0.2.0'
-    compile 'com.android.support:appcompat-v7:26+'
+    compile 'com.android.support:appcompat-v7:+'
 }


### PR DESCRIPTION
Fix conflict with plugin cordova-plugin-crosswalk-webview && phonegap-plugin-barcodescanner

How to test : 
- Init a cordova project
- `cordova plugin add phonegap-plugin-barcodescanner`
- `cordova plugin add ~/code/sdk/CDVNavitiaSDKUX --nofetch --verbose`
- You should be able to open Journey screens 🎉 